### PR TITLE
Update profile design

### DIFF
--- a/app/hobby/[hobby].tsx
+++ b/app/hobby/[hobby].tsx
@@ -1,0 +1,61 @@
+import { useLocalSearchParams } from 'expo-router';
+import React, { useEffect, useState } from 'react';
+import { View, Text, FlatList, ActivityIndicator, Image, StyleSheet } from 'react-native';
+import { collection, getDocs, orderBy, query, where } from 'firebase/firestore';
+import { db } from '@/lib/firebase';
+import type { Artwork } from '@/app/types/artwork';
+
+export default function HobbyScreen() {
+  const { hobby } = useLocalSearchParams<{ hobby: string }>();
+  const [loading, setLoading] = useState(true);
+  const [artworks, setArtworks] = useState<Artwork[]>([]);
+
+  useEffect(() => {
+    async function fetchArt() {
+      try {
+        setLoading(true);
+        const snap = await getDocs(
+          query(
+            collection(db, 'artworks'),
+            where('ownerUid', '==', 'anon'),
+            where('category', '==', hobby),
+            orderBy('createdAt', 'desc')
+          )
+        );
+        const items = snap.docs.map(d => ({ id: d.id, ...(d.data() as any) })) as Artwork[];
+        setArtworks(items);
+      } finally {
+        setLoading(false);
+      }
+    }
+    if (hobby) fetchArt();
+  }, [hobby]);
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>{hobby}</Text>
+      {loading ? (
+        <ActivityIndicator style={{ marginTop: 20 }} />
+      ) : (
+        <FlatList
+          data={artworks}
+          keyExtractor={(a) => a.id}
+          renderItem={({ item }) => (
+            <View style={styles.card}>
+              <Image source={{ uri: item.url }} style={styles.image} />
+              {item.title && <Text style={styles.caption}>{item.title}</Text>}
+            </View>
+          )}
+        />
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, paddingTop: 60 },
+  title: { fontSize: 24, fontWeight: 'bold', textAlign: 'center', marginBottom: 20 },
+  card: { marginBottom: 16, alignItems: 'center' },
+  image: { width: 300, height: 300, borderRadius: 12 },
+  caption: { marginTop: 8, fontSize: 16 },
+});

--- a/components/profilescreen/WhiteboardHeader.tsx
+++ b/components/profilescreen/WhiteboardHeader.tsx
@@ -30,7 +30,8 @@ export default function WhiteboardHeader({
   } = useWhiteboard();
 
   const insets = useSafeAreaInsets();
-  const calculatedHeaderHeight = SCREEN_HEIGHT * 0.4 + insets.top;
+  // The whiteboard should fill the entire first screen height
+  const calculatedHeaderHeight = SCREEN_HEIGHT + insets.top;
   const [vectorStrokes, setVectorStrokes] = useState<Stroke[]>([]);
   const [vectorStickers, setVectorStickers] = useState<Sticker[]>([]);
   console.log('Vector Sticker', vectorStickers);
@@ -47,7 +48,8 @@ export default function WhiteboardHeader({
         style={[
           styles.header,
           {
-            height: SCREEN_HEIGHT * 0.4 + insets.top,
+            // Fill the entire screen for the whiteboard
+            height: SCREEN_HEIGHT + insets.top,
             paddingTop: insets.top + 12,
           },
         ]}
@@ -108,7 +110,8 @@ const SCREEN_HEIGHT = Dimensions.get('window').height;
 const styles = StyleSheet.create({
   header: {
     width: '100%',
-    height: SCREEN_HEIGHT * .4,
+    // The whiteboard now takes up the whole screen
+    height: SCREEN_HEIGHT,
     backgroundColor: '#fff',
     justifyContent: 'center',
     alignItems: 'center',


### PR DESCRIPTION
## Summary
- expand whiteboard to full-screen height
- redesign profile screen layout with horizontal page swipe
- add Showcase and hobby icons
- link hobby icons to new hobby screen

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683cbc0f1e94832fade3d699e0e39f4f